### PR TITLE
Add "-t", "-G" options and BED output format.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ GIT_COMMIT_INFO			= $(shell git log -1 --format='%ci  commit: %h')
 CXX				= g++
 ICPC				= icpc
 
-CXXFLAGS			= -Wall -O3 -march=native -D NDEBUG
-CXXFLAGS_INTEL			= -Wall -O3 -march=native -D NDEBUG -static
+CXXFLAGS			= -Wall -std=c++0x -O3 -march=native -D NDEBUG
+CXXFLAGS_INTEL			= -Wall -std=c++0x -O3 -march=native -D NDEBUG -static
 CXXFLAGS_GIT_COMMIT_INFO	= -D GIT_COMMIT_INFO="\"$(GIT_COMMIT_INFO)\""
 
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Options:
 -l Mask lowercase letters
 -p Pseudocount (0.375)
 -t Keep top X clusters per sequence (0 (= all))
+-G Use genomic coordinates (extracted from sequence name)
+   0: zero-based start coordinate
+   1: one-based start coordinate
 -f Output format (0)
    0: per sequence (default)
    1: per sequence, concise format
@@ -161,6 +164,17 @@ default values are designed to give sensible results.
    If set to 1 or higher, keep only this amount of best scoring clusters
    above the cluster threshold for each sequence. If set to 0, keep all
    clusters above the cluster threshold for each sequence.
+-G Extract genomic coordinates from sequence name and output genomic
+   coordinates instead of relative coordinates.
+   Examples of sequence names from which chromosome names and start
+   positions can be extracted:
+     - chr10:123456
+     - chr10:123456-234567
+     - chr10:123456@@gene_name
+     - chr10:123456-234567@@gene_name
+   Specify if the start coordinate is zero- or one-based:
+     0: zero-based
+     1: one-based
 -f Output format (default = 0).
    0: Print the clusters in the first sequence sorted by score, then the
       clusters in the second sequence sorted by score, etc.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Options:
 -r Range in bp for counting local nucleotide abundances (100)
 -l Mask lowercase letters
 -p Pseudocount (0.375)
+-t Keep top X clusters per sequence (0 (= all))
 -f Output format (0)
    0: per sequence (default)
    1: per sequence, concise format
@@ -156,6 +157,10 @@ default values are designed to give sensible results.
    are a standard way of estimating underlying frequencies from a limited
    number of observations. If your matrices contain probabilities rather
    than counts, you should probably set this parameter to zero.
+-t Keep X top clusters per sequence (default = 0 (= all)).
+   If set to 1 or higher, keep only this amount of best scoring clusters
+   above the cluster threshold for each sequence. If set to 0, keep all
+   clusters above the cluster threshold for each sequence.
 -f Output format (default = 0).
    0: Print the clusters in the first sequence sorted by score, then the
       clusters in the second sequence sorted by score, etc.
@@ -165,7 +170,7 @@ default values are designed to give sensible results.
    3: Concise version of 2, omitting details of individual motif matches.
    4: Same than 1, but all info on one line.
 
-Example usage: cbust -g20 -l mymotifs myseqs.fa
+Example usage: cbust -g 20 -l mymotifs myseqs.fa
 
 For more information on the Cluster-Buster algorithm, see:
 Cluster-Buster: Finding dense clusters of motifs in DNA sequences

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Options:
    2: sorted by cluster score
    3: sorted by cluster score, concise format
    4: per sequence, consise format on one line
+   5: BED file
 ```
 
 ```
@@ -176,13 +177,14 @@ default values are designed to give sensible results.
      0: zero-based
      1: one-based
 -f Output format (default = 0).
-   0: Print the clusters in the first sequence sorted by score, then the
-      clusters in the second sequence sorted by score, etc.
-   1: Concise version of 0, omitting details of individual motif matches.
-   2: Sort all clusters by score, regardless of which sequence they come
-      from.
-   3: Concise version of 2, omitting details of individual motif matches.
-   4: Same than 1, but all info on one line.
+     0: Print the clusters in the first sequence sorted by score, then the
+        clusters in the second sequence sorted by score, etc.
+     1: Concise version of 0, omitting details of individual motif matches.
+     2: Sort all clusters by score, regardless of which sequence they come
+        from.
+     3: Concise version of 2, omitting details of individual motif matches.
+     4: Same than 1, but all info on one line.
+     5: BED file with all info.
 
 Example usage: cbust -g 20 -l mymotifs myseqs.fa
 

--- a/args.cpp
+++ b/args.cpp
@@ -190,6 +190,9 @@ void args::parse(int argc, char **argv) {
       "     3: Concise version of 2, omitting details of individual motif "
       "matches.\n"
       "     4: Same than 1, but all info on one line.\n"
+      "     4: Sort all clusters by score and output sequence name, score, "
+      "number\n"
+      "        of the sequence in the FASTA file, ranking of the score.\n"
       "     5: BED file with all info.\n"
       "\n"
       "Example usage: cbust -g 20 -l mymotifs myseqs.fa\n"
@@ -225,7 +228,7 @@ void args::parse(int argc, char **argv) {
       "   1: per sequence, concise format\n"
       "   2: sorted by cluster score\n"
       "   3: sorted by cluster score, concise format\n"
-      "   4: per sequence, consise format on one line\n"
+      "   4: sorted by cluster score: seq name, score, seq number, rank\n"
       "   5: BED file\n"
       //"-e  transition probability to HMM end state (tau) (" +
       //mcf::tostring(tau) + ")\n"
@@ -273,7 +276,7 @@ void args::parse(int argc, char **argv) {
         out_format = BY_SCORE_CONCISE;
         break;
       case 4:
-        out_format = BY_SEQUENCE_CONCISE_ONE_LINE;
+        out_format = SEQUENCE_NAME_SORTED_BY_SCORE;
         break;
       case 5:
         out_format = BED;

--- a/args.cpp
+++ b/args.cpp
@@ -187,22 +187,15 @@ void args::parse(int argc, char **argv) {
       "-h Help: print documentation\n"
       "-V Show version\n"
       "-v Verbose\n"
-      "-c Cluster score threshold (" +
-      mcf::tostring(score_thresh) + ")\n"
-                                    "-m Motif score threshold (" +
-      mcf::tostring(motif_thresh) +
-      ")\n"
+      "-c Cluster score threshold (" + mcf::tostring(score_thresh) + ")\n"
+      "-m Motif score threshold (" + mcf::tostring(motif_thresh) + ")\n"
       "-g Expected gap (bp) between neighboring motifs in a cluster (" +
-      mcf::tostring(e_gap) +
-      ")\n"
+      mcf::tostring(e_gap) + ")\n"
       "-r Range in bp for counting local nucleotide abundances (" +
       mcf::tostring(bg_range) + ")\n"
-                                "-l Mask lowercase letters\n"
-                                "-p Pseudocount (" +
-      mcf::tostring(pseudo) + ")\n"
-                              "-f Output format (" +
-      mcf::tostring(out_format) +
-      ")\n"
+      "-l Mask lowercase letters\n"
+      "-p Pseudocount (" + mcf::tostring(pseudo) + ")\n"
+      "-f Output format (" + mcf::tostring(out_format) + ")\n"
       "   0: per sequence (default)\n"
       "   1: per sequence, concise format\n"
       "   2: sorted by cluster score\n"

--- a/args.cpp
+++ b/args.cpp
@@ -14,6 +14,7 @@ format out_format = BY_SEQUENCE;
 uint bg_range = 100;
 bool mask_lower = false;
 double pseudo = 0.375;
+uint keep_top_x_clusters_per_sequence = 0;
 double tau = 0;
 bool verbose = false;
 }
@@ -156,6 +157,12 @@ void args::parse(int argc, char **argv) {
       "   number of observations. If your matrices contain probabilities "
       "rather\n"
       "   than counts, you should probably set this parameter to zero.\n"
+      "-t Keep X top clusters per sequence (default = 0 (= all)).\n"
+      "   If set to 1 or higher, keep only this amount of best scoring "
+      "clusters\n"
+      "   above the cluster threshold for each sequence. If set to 0, "
+      "keep all\n"
+      "   clusters above the cluster threshold for each sequence.\n"
       "-f Output format (default = " +
       mcf::tostring(out_format) +
       ").\n"
@@ -171,7 +178,7 @@ void args::parse(int argc, char **argv) {
       "matches.\n"
       "   4: Same than 1, but all info on one line.\n"
       "\n"
-      "Example usage: cbust -g20 -l mymotifs myseqs.fa\n"
+      "Example usage: cbust -g 20 -l mymotifs myseqs.fa\n"
       "\n"
       "For more information on the Cluster-Buster algorithm, see:\n"
       "Cluster-Buster: Finding dense clusters of motifs in DNA sequences\n"
@@ -195,6 +202,7 @@ void args::parse(int argc, char **argv) {
       mcf::tostring(bg_range) + ")\n"
       "-l Mask lowercase letters\n"
       "-p Pseudocount (" + mcf::tostring(pseudo) + ")\n"
+      "-t Keep top X clusters per sequence (0 (= all))\n"
       "-f Output format (" + mcf::tostring(out_format) + ")\n"
       "   0: per sequence (default)\n"
       "   1: per sequence, concise format\n"
@@ -207,7 +215,7 @@ void args::parse(int argc, char **argv) {
 
   int c;
 
-  while ((c = getopt(argc, argv, "hVvc:m:g:f:r:lp:e:")) != -1)
+  while ((c = getopt(argc, argv, "hVvc:m:g:f:r:lp:t:e:")) != -1)
     switch (c) {
     case 'h':
       cout << doc << endl;
@@ -264,6 +272,9 @@ void args::parse(int argc, char **argv) {
       if (pseudo < 0)
         mcf::die("Pseudocount should be >= zero");
       break;
+    case 't':
+      keep_top_x_clusters_per_sequence = atoi(optarg);
+      break;
     case 'e':
       tau = atof(optarg);
       if (tau < 0 || tau >= 1)
@@ -289,6 +300,9 @@ void args::print(ostream &strm, uint seq_num, uint mat_num) {
        << "Range for local abundances: " << bg_range << '\n'
        << "Lowercase filtering " << (mask_lower ? "ON\n" : "OFF\n")
        << "Pseudocount: " << pseudo << '\n'
+       << "Keep top X clusters per sequence: "
+       << (keep_top_x_clusters_per_sequence > 0
+           ? mcf::tostring(keep_top_x_clusters_per_sequence) : "0 (= all)") << '\n'
        << "Cluster score threshold: " << score_thresh << '\n'
        << "Motif score threshold: " << motif_thresh << '\n'
        //    << "Tau: " << tau << '\n'

--- a/args.cpp
+++ b/args.cpp
@@ -179,17 +179,18 @@ void args::parse(int argc, char **argv) {
       "-f Output format (default = " +
       mcf::tostring(out_format) +
       ").\n"
-      "   0: Print the clusters in the first sequence sorted by score, then "
+      "     0: Print the clusters in the first sequence sorted by score, then "
       "the\n"
-      "      clusters in the second sequence sorted by score, etc.\n"
-      "   1: Concise version of 0, omitting details of individual motif "
+      "        clusters in the second sequence sorted by score, etc.\n"
+      "     1: Concise version of 0, omitting details of individual motif "
       "matches.\n"
-      "   2: Sort all clusters by score, regardless of which sequence they "
+      "     2: Sort all clusters by score, regardless of which sequence they "
       "come\n"
-      "      from.\n"
-      "   3: Concise version of 2, omitting details of individual motif "
+      "        from.\n"
+      "     3: Concise version of 2, omitting details of individual motif "
       "matches.\n"
-      "   4: Same than 1, but all info on one line.\n"
+      "     4: Same than 1, but all info on one line.\n"
+      "     5: BED file with all info.\n"
       "\n"
       "Example usage: cbust -g 20 -l mymotifs myseqs.fa\n"
       "\n"
@@ -225,6 +226,7 @@ void args::parse(int argc, char **argv) {
       "   2: sorted by cluster score\n"
       "   3: sorted by cluster score, concise format\n"
       "   4: per sequence, consise format on one line\n"
+      "   5: BED file\n"
       //"-e  transition probability to HMM end state (tau) (" +
       //mcf::tostring(tau) + ")\n"
       ;
@@ -273,8 +275,11 @@ void args::parse(int argc, char **argv) {
       case 4:
         out_format = BY_SEQUENCE_CONCISE_ONE_LINE;
         break;
+      case 5:
+        out_format = BED;
+        break;
       default:
-        mcf::die("Format should be 0, 1, 2, 3 or 4");
+        mcf::die("Format should be 0, 1, 2, 3, 4 or 5");
       }
       break;
     case 'r':

--- a/args.hpp
+++ b/args.hpp
@@ -17,6 +17,7 @@ extern uint bg_range;   // Go up to this far either side of current base
                         // when counting local base abundances
 extern bool mask_lower; // mask lowercase letters?
 extern double pseudo;   // Pseudocount to add to all matrix entries
+extern uint keep_top_x_clusters_per_sequence; // Keep top X clusters per sequence
 extern double tau;      // Transition probability to "end" state of HMM
 extern bool verbose;    // Be verbose or not
 

--- a/args.hpp
+++ b/args.hpp
@@ -11,7 +11,7 @@ extern double score_thresh; // Print clusters with scores >= this
 extern double motif_thresh; // Print motifs inside clusters with scores >= this
 extern double e_gap;        // Expected distance between pairs of cis-elements
 extern bool gap_specified;  // Did the user specify a value for e_gap?
-enum format { BY_SEQUENCE, BY_SEQUENCE_CONCISE, BY_SCORE, BY_SCORE_CONCISE, BY_SEQUENCE_CONCISE_ONE_LINE };
+enum format { BY_SEQUENCE, BY_SEQUENCE_CONCISE, BY_SCORE, BY_SCORE_CONCISE, BY_SEQUENCE_CONCISE_ONE_LINE, BED };
 extern format out_format;
 extern uint bg_range;   // Go up to this far either side of current base
                         // when counting local base abundances

--- a/args.hpp
+++ b/args.hpp
@@ -18,6 +18,8 @@ extern uint bg_range;   // Go up to this far either side of current base
 extern bool mask_lower; // mask lowercase letters?
 extern double pseudo;   // Pseudocount to add to all matrix entries
 extern uint keep_top_x_clusters_per_sequence; // Keep top X clusters per sequence
+extern bool genomic_coordinates;              // Use genomic coordinates instead of relative coordinates
+extern bool zero_based; // Is start coordinate in sequence name zero-based or one-based
 extern double tau;      // Transition probability to "end" state of HMM
 extern bool verbose;    // Be verbose or not
 

--- a/args.hpp
+++ b/args.hpp
@@ -11,7 +11,7 @@ extern double score_thresh; // Print clusters with scores >= this
 extern double motif_thresh; // Print motifs inside clusters with scores >= this
 extern double e_gap;        // Expected distance between pairs of cis-elements
 extern bool gap_specified;  // Did the user specify a value for e_gap?
-enum format { BY_SEQUENCE, BY_SEQUENCE_CONCISE, BY_SCORE, BY_SCORE_CONCISE, BY_SEQUENCE_CONCISE_ONE_LINE, BED };
+enum format { BY_SEQUENCE, BY_SEQUENCE_CONCISE, BY_SCORE, BY_SCORE_CONCISE, SEQUENCE_NAME_SORTED_BY_SCORE, BED };
 extern format out_format;
 extern uint bg_range;   // Go up to this far either side of current base
                         // when counting local base abundances


### PR DESCRIPTION
Add new options:​
  -t Keep top X clusters per sequence (0 (= all))
  -G Use genomic coordinates (extracted from sequence name)
      0: zero-based start coordinate
      1: one-based start coordinate
  -f Output format
     4: sorted by cluster score: seq name, score, seq number, rank
     5: BED file
